### PR TITLE
Adding the posibility of resetting some variables to default values

### DIFF
--- a/config-parser.sh
+++ b/config-parser.sh
@@ -1,9 +1,15 @@
 # function to parse the ini style configuration file
-config_parser () {
+function config_parser () {
 	local iniFile="$1";
 	local tmpFile=$( mktemp /tmp/`basename $iniFile`.XXXXXX );
+	# create a tmpFiles mask, so we may delete multiple files at once
+	local tmpFiles="${tmpFile%%??????}*";
 	local intLines;
 	local binSED=$( which sed );
+
+	# clean up all remaining, specific tmpFiles before the run - then
+	# newly created file will be kept for debugging purposes
+	rm -f $tmpFiles;
 
 	# copy the ini file to the temporary location
 	cp $iniFile $tmpFile;
@@ -14,10 +20,21 @@ config_parser () {
 	# transform section labels into function declaration
 	$binSED -i -e 's/\[\([A-Za-z0-9_]*\)\]/config.section.\1() \{/g' $tmpFile;
 	$binSED -i -e 's/config\.section\./\}\'$'\nconfig\.section\./g' $tmpFile;
+	# add the reset call: reset some variables to defaults
+	$binSED -i -e 's/\(\) {/ {\nreset;/g' $tmpFile;
+	# remove the reset call from the reset function itself
+	$binSED -i -e '/config\.section\.reset\(\)/{n;N;d}' $tmpFile;
 
 	# remove first line
-	$binSED -i -e '1d' $tmpFile;
-
+	#$binSED -i -e '1d' $tmpFile;
+	# replace the first line withe the definition for the reset command, this will be called by all
+	# function definied out of the iniFile sections, except for the "[reset]" section (if one exists)
+	# to use this functionality, there has to be a section "[reset]" in the iniFile, where all default
+	# values must be defined. Every section call will at first call the "reset;" command, so variables
+	# used in several sections must only be defined, if they have other values as the section specific one.
+	# If no "[reset]" section exists, the command quits the function without error messages
+	$binSED -i -e '1 s/^.*$/function reset\(\) { config\.section\.reset 2\> \/dev\/null \|\| return 1; }\n/g' $tmpFile;
+	
 	# add the last brace
 	echo -e "\n}" >> $tmpFile;
 
@@ -25,5 +42,5 @@ config_parser () {
 	source $tmpFile;
 
 	# clean up
-	rm -f $tmpFile;
+	#rm -f $tmpFile;
 }


### PR DESCRIPTION
As I needed some variables with same name and purpose in several sections and had also only some of these variables set and others only used in a default mode (e.g. "lineEnding" has normally to be an empty string, but in some cases, I needed a ";" (semicolon), and to avoid to repeat "thousand times" the line --lineEndig=""--, I came up with the reset idea.
In the ini-file das to be a "reset" section, in which all values are declared, which are often used and mostly with a default value. So only in some section where this varys, one must the define a specific value - in all other cases, the value defined in the "reset" exction will fit. The "reset" command will be called as first command in every section function, if no "reset" section exists, the comman quits itself quietly.